### PR TITLE
Make admins admins again

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_open_lab_scheduler/entities/Admin.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_open_lab_scheduler/entities/Admin.java
@@ -20,6 +20,10 @@ public class Admin {
     public Admin() {
     }
 
+    public Admin(String email) {
+        this.email = email;
+    }
+
     public void setId(long id) {
         this.id = id;
     }

--- a/src/main/java/edu/ucsb/cs56/ucsb_open_lab_scheduler/repositories/AdminRepository.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_open_lab_scheduler/repositories/AdminRepository.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs56.ucsb_open_lab_scheduler.repositories;
 
+import java.util.List;
+
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +9,5 @@ import edu.ucsb.cs56.ucsb_open_lab_scheduler.entities.Admin;
 
 @Repository
 public interface AdminRepository extends CrudRepository<Admin, Long> {
-  Admin findByEmail(String email);
+  public List<Admin> findByEmail(String email);
 }

--- a/src/main/java/edu/ucsb/cs56/ucsb_open_lab_scheduler/services/GoogleMembershipService.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_open_lab_scheduler/services/GoogleMembershipService.java
@@ -10,7 +10,7 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
-
+import edu.ucsb.cs56.ucsb_open_lab_scheduler.repositories.AdminRepository;
 
 /**
  * Service object that wraps the UCSB Academic Curriculum API
@@ -28,6 +28,9 @@ public class GoogleMembershipService implements MembershipService {
 
     @Autowired
     private OAuth2AuthorizedClientService clientService;
+
+    @Autowired
+    private AdminRepository adminRepository;
 
     /**
      * is current logged in user a member but NOT an admin of the google org
@@ -50,7 +53,7 @@ public class GoogleMembershipService implements MembershipService {
 
     public boolean hasRole(OAuth2AuthenticationToken oauthToken, String roleToTest) {
 
-        logger.info("adminEmail=["+adminEmail+"]");
+        logger.info("adminEmail=[" + adminEmail + "]");
 
         if (oauthToken == null) {
             return false;
@@ -67,10 +70,10 @@ public class GoogleMembershipService implements MembershipService {
         // hd is the domain of the email, e.g. ucsb.edu
         String hostedDomain = (String) oAuth2User.getAttributes().get("hd");
 
-        logger.info("email=["+email+"]");
-        logger.info("hostedDomain="+hostedDomain);
+        logger.info("email=[" + email + "]");
+        logger.info("hostedDomain=" + hostedDomain);
 
-        if (roleToTest.equals("admin") && email.equals(adminEmail)) {
+        if (roleToTest.equals("admin") && isAdminEmail(email)) {
             return true;
         }
 
@@ -79,6 +82,10 @@ public class GoogleMembershipService implements MembershipService {
         }
 
         return false;
+    }
+
+    private boolean isAdminEmail(String email) {
+        return (!adminRepository.findByEmail(email).isEmpty() || email.equals(adminEmail));
     }
 
 }


### PR DESCRIPTION
Title aside, admins on the admin table are now recognized as admins by GoogleMembershipService.

The OG admin in the `application.properties` cannot be removed. 
# Ever.