### PR TITLE
aq - Fixed formatting of the example CSV in CourseOffering tab

### DIFF
--- a/src/main/resources/templates/courseOffering/courseOffering.html
+++ b/src/main/resources/templates/courseOffering/courseOffering.html
@@ -16,9 +16,9 @@
         <h2 class="my-5">CS56 W20 Open Lab Hours</h2>
         <h4>CSV must be in the following format:</h4>
         <pre>
-          courseId,quarter,instructorName,instructorEmail
-          CMPSC 56,W20,Conrad,conrad@ucsb.edu
-          CMPSC 48,F19,Richert Wang,richert@ucsb.edu
+courseId,quarter,instructorName,instructorEmail
+CMPSC 56,W20,Conrad,conrad@ucsb.edu
+CMPSC 48,F19,Richert Wang,richert@ucsb.edu
         </pre>
         <br/>
         <form action="/courseOffering/upload" method="post" enctype="multipart/form-data">


### PR DESCRIPTION
Changed 3 lines of code to remove tabbing to make the example CSV in the CourseOffering page match the other example CSVs.