### PR TITLE
t 5pm d cb tutorExportCSV - Added button so admins can export tutors to CSV

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_open_lab_scheduler/controllers/TutorController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_open_lab_scheduler/controllers/TutorController.java
@@ -1,8 +1,13 @@
 package edu.ucsb.cs56.ucsb_open_lab_scheduler.controllers;
 
+import com.opencsv.CSVWriter;
+import com.opencsv.bean.StatefulBeanToCsv;
+import com.opencsv.bean.StatefulBeanToCsvBuilder;
+import edu.ucsb.cs56.ucsb_open_lab_scheduler.entities.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
@@ -33,6 +38,8 @@ import edu.ucsb.cs56.ucsb_open_lab_scheduler.entities.TutorAssignment;
 import edu.ucsb.cs56.ucsb_open_lab_scheduler.repositories.TutorAssignmentRepository;
 import edu.ucsb.cs56.ucsb_open_lab_scheduler.repositories.TutorRepository;
 import edu.ucsb.cs56.ucsb_open_lab_scheduler.services.CSVToObjectService;
+
+import javax.servlet.http.HttpServletResponse;
 
 @Controller
 public class TutorController {
@@ -128,5 +135,27 @@ public class TutorController {
         tutorRepository.save(tutor);
 
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/tutors/tutors.csv")
+    public void exportCSV(HttpServletResponse response) throws Exception {
+
+        //set file name and content type
+        String filename = "tutors.csv";
+
+        response.setContentType("text/csv");
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
+                "attachment; filename=\"" + filename + "\"");
+
+        //create a csv writer
+        StatefulBeanToCsv<Tutor> writer = new StatefulBeanToCsvBuilder<Tutor>(response.getWriter())
+                .withQuotechar(CSVWriter.NO_QUOTE_CHARACTER)
+                .withSeparator(CSVWriter.DEFAULT_SEPARATOR)
+                .withOrderedResults(false)
+                .build();
+
+        //write all users to csv file
+        writer.write(tutorRepository.findAll().iterator());
+
     }
 }

--- a/src/main/java/edu/ucsb/cs56/ucsb_open_lab_scheduler/entities/Tutor.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_open_lab_scheduler/entities/Tutor.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs56.ucsb_open_lab_scheduler.entities;
 
+import com.opencsv.bean.CsvBindByName;
 import com.opencsv.bean.CsvBindByPosition;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -15,14 +16,17 @@ public class Tutor{
     private long id;
 
     @CsvBindByPosition(position = 0)
+    @CsvBindByName
     @NotBlank(message = "Email is required")
     private String email;
 
     @CsvBindByPosition(position = 1)
+    @CsvBindByName
     @NotBlank(message = "Last name is required")
     private String lastName;
 
     @CsvBindByPosition(position = 2)
+    @CsvBindByName
     @NotBlank(message = "First name is required")
     private String firstName;
 

--- a/src/main/resources/templates/tutors/tutors.html
+++ b/src/main/resources/templates/tutors/tutors.html
@@ -30,6 +30,7 @@ phtcon@ucsb.edu,Conrad,Phill
         <br>
 
         <a href="/tutors/add" class="btn btn-primary" style="display: inline-block" role="button">Create New Tutor</a>
+          <a href="/tutors/tutors.csv" type="button" class="btn btn-secondary">Download Tutors to CSV</a>
 
         <br><br>
 


### PR DESCRIPTION
"As an admin, I can download my tutors to a CSV file so that I can back up my data"

This PR adds a "Download tutors to CSV" button on the tutors page and a new REST endpoint at /tutors/tutors.csv that downloads the CSV file.

Major changes:
- TutorController: Added new endpoint
- Tutors.html template: Added the button