### PR TITLE
cs - added links to staff pages for each course in table

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_open_lab_scheduler/controllers/CourseOfferingController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_open_lab_scheduler/controllers/CourseOfferingController.java
@@ -4,8 +4,10 @@ import javax.validation.Valid;
 
 import edu.ucsb.cs56.ucsb_open_lab_scheduler.advice.AuthControllerAdvice;
 import edu.ucsb.cs56.ucsb_open_lab_scheduler.entities.CourseOffering;
+import edu.ucsb.cs56.ucsb_open_lab_scheduler.entities.TimeSlotAssignment;
 import edu.ucsb.cs56.ucsb_open_lab_scheduler.entities.TutorAssignment;
 import edu.ucsb.cs56.ucsb_open_lab_scheduler.repositories.CourseOfferingRepository;
+import edu.ucsb.cs56.ucsb_open_lab_scheduler.repositories.TimeSlotAssignmentRepository;
 import edu.ucsb.cs56.ucsb_open_lab_scheduler.repositories.TutorAssignmentRepository;
 import edu.ucsb.cs56.ucsb_open_lab_scheduler.services.CSVToObjectService;
 import org.slf4j.Logger;
@@ -27,6 +29,7 @@ import java.util.Optional;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.util.ArrayList;
 import java.util.List;
 
 @Controller
@@ -44,6 +47,9 @@ public class CourseOfferingController {
 
     @Autowired
     TutorAssignmentRepository tutorAssignmentRepository;
+
+    @Autowired
+    TimeSlotAssignmentRepository timeSlotAssignmentRepository;
 
     @GetMapping("/courseOffering")
     public String dashboard(Model model, OAuth2AuthenticationToken token, RedirectAttributes redirAttrs) {
@@ -69,11 +75,41 @@ public class CourseOfferingController {
             courseOfferingRepository.saveAll(courseOfferings);
         } catch (IOException e) {
             log.error(e.toString());
-        }catch(RuntimeException a){
+        } catch (RuntimeException a) {
             redirAttrs.addFlashAttribute("alertDanger", "Please enter the correct csv files");
             return "redirect:/courseOffering";
         }
         return "redirect:/courseOffering";
+    }
+
+    @GetMapping("/courseOffering/staff/{id}")
+    public String staff(@PathVariable("id") long id, Model model, OAuth2AuthenticationToken token,
+            RedirectAttributes redirAttrs) {
+        String role = authControllerAdvice.getRole(token);
+        if (!role.equals("Admin")) {
+            redirAttrs.addFlashAttribute("alertDanger", "You do not have permission to access that page");
+            return "redirect:/";
+        }
+
+        Optional<CourseOffering> course = courseOfferingRepository.findById(id);
+        if (!course.isPresent()) {
+            redirAttrs.addFlashAttribute("alertDanger", "Course with that id does not exist.");
+        } else {
+            List<TutorAssignment> tutorAssignments = tutorAssignmentRepository.findByCourseOffering(course.get());
+
+            List<Integer> numberTimeSlotsAssigned = new ArrayList<Integer>();
+
+            for (TutorAssignment tutorAssignment : tutorAssignments) {
+                List<TimeSlotAssignment> timeSlotAssignments = timeSlotAssignmentRepository
+                        .findByTutorAndCourseOffering(tutorAssignment.getTutor(), course.get());
+                numberTimeSlotsAssigned.add(timeSlotAssignments.size());
+            }
+            model.addAttribute("course", course.get());
+            model.addAttribute("tutorAssignments", tutorAssignments);
+            model.addAttribute("numberTimeSlotsAssigned", numberTimeSlotsAssigned);
+        }
+
+        return "courseOffering/staff";
     }
 
     @GetMapping("/courseOffering/delete/{id}")
@@ -123,9 +159,9 @@ public class CourseOfferingController {
         return "courseOffering/create";
     }
 
-
     @PostMapping("/courseOffering/add")
-    public String add(@Valid CourseOffering courseOffering, BindingResult result, Model model, RedirectAttributes redirAttrs, OAuth2AuthenticationToken token) {
+    public String add(@Valid CourseOffering courseOffering, BindingResult result, Model model,
+            RedirectAttributes redirAttrs, OAuth2AuthenticationToken token) {
         String role = authControllerAdvice.getRole(token);
         if (!role.equals("Admin")) {
             redirAttrs.addFlashAttribute("alertDanger", "You do not have permission to access that page");

--- a/src/main/resources/templates/courseOffering/courseOffering.html
+++ b/src/main/resources/templates/courseOffering/courseOffering.html
@@ -1,5 +1,3 @@
-
-
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
 
@@ -28,7 +26,7 @@ CMPSC 48,F19,Richert Wang,richert@ucsb.edu
           <input type="file" name="csv" id="csv" accept="text/csv">
           <input type="submit" class="btn btn-primary" value="Submit">
         </form>
-        <br/>
+        <br />
         <a href="/courseOffering/create" class="btn btn-success">Create</a>
         <table class="table table-striped table-responsive-md">
           <thead>
@@ -40,6 +38,9 @@ CMPSC 48,F19,Richert Wang,richert@ucsb.edu
               <th>TAs</th>
               <th>LAs</th>
               <th>190J</th>
+              <th> </th>
+              <th> </th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -51,6 +52,11 @@ CMPSC 48,F19,Richert Wang,richert@ucsb.edu
               <td th:text="${co.numTAs}"></td>
               <td th:text="${co.numLAs}"></td>
               <td th:text="${co.num190J}"></td>
+              <td>
+                <form th:action="@{/courseOffering/staff/{id}(id=${co.id})}" th:method="get">
+                  <button type="submit" class="btn btn-primary">Staff</button>
+                </form>
+              </td>
               <td>
                 <form th:action="@{/courseOffering/edit/{id}(id=${co.id})}" th:method="get">
                   <button type="submit" class="btn btn-success">Edit</button>

--- a/src/main/resources/templates/courseOffering/staff.html
+++ b/src/main/resources/templates/courseOffering/staff.html
@@ -1,0 +1,69 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+
+<head>
+    <div th:replace="bootstrap/title.html"></div>
+    <div th:replace="bootstrap/bootstrap_head.html"></div>
+</head>
+
+<body>
+    <div class="container">
+        <div th:replace="bootstrap/bootstrap_nav_header.html"></div>
+
+        <div class="row">
+            <div class="col-md-8">
+
+                <h2 class="my-5">CS56 W20 Open Lab Hours</h2>
+                <br />
+                <h4>Staff:</h4>
+
+                <table class="table table-striped table-responsive-md">
+                    <thead>
+                        <tr>
+                            <th>CourseId</th>
+                            <th>Quarter</th>
+                            <th>Instructor Name</th>
+                            <th>Instructor Email</th>
+                            <th> </th>
+                        </tr>
+                    </thead>
+                    <br />
+                    <tbody>
+                        <tr th:with="co=${course}">
+                            <td th:text="${co.courseId}"></td>
+                            <td th:text="${co.quarter}"></td>
+                            <td th:text="${co.instructorName}"></td>
+                            <td th:text="${co.instructorEmail}"></td>
+                            <td></td>
+
+                        </tr>
+                    </tbody>
+                </table>
+
+                <table class="table table-striped table-responsive-md">
+                    <thead>
+                        <tr>
+                            <th>Staff</th>
+                            <th>Number of Time Slots Signed Up For</th>
+                        </tr>
+                    </thead>
+                    <br />
+                    <tbody>
+                        <tr th:each="t, tStat : ${tutorAssignments}">
+                            <td th:text="${t.tutor.getFullName()}"></td>
+                            <td th:text="${numberTimeSlotsAssigned[tStat.index].toString()}"></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <form th:action="@{/courseOffering/}" th:method="get">
+                    <button type="submit" class="btn btn-primary btn-block">Back</button>
+                </form>
+            </div>
+        </div>
+
+        <div th:replace="bootstrap/bootstrap_footer.html"></div>
+    </div>
+    <div th:replace="bootstrap/bootstrap_scripts.html"></div>
+</body>
+
+</html>


### PR DESCRIPTION
This pull request adds the ability to access a staff page for each course.
At the staff page, admin may see which staff members are assigned to a particular course, and how many open lab hour time slots each staff member has signed up for.

This was done by:
-adding a courseOffering/staff.html page that displays information specific to each course
-adding a mapping in the CourseOfferingController to staff.html
-adding a link in the course list table to each course's specific staff page

Files changed:
-resources/templates/courseOffering/staff.html --created
-controllers/CourseOfferingController.java --edited